### PR TITLE
Browser support + marginally smaller modules

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -6,6 +6,7 @@
     "debug": false,
     "noExportMemory": true,
     "optimize": true,
+    "converge": true,
     "noAssert": true
   }
 }

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,3 +1,3 @@
 export function f64_pow(x: f64, y: f64): f64 {
-  return Math.pow(x, y);
+  return inline.always(Math.pow(x, y));
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
 import { MathWasmBase64 } from "./build/math.js";
 
-const exports = (await WebAssembly.instantiate(Buffer.from(MathWasmBase64, "base64"))).instance.exports;
-
-export function f64_pow(value, exponent) {
-  return exports.f64_pow(value, exponent);
-}
+export const {f64_pow} = (await WebAssembly.instantiateStreaming(fetch(MathWasmBase64))).instance.exports;

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -2,4 +2,4 @@ import { readFileSync, writeFileSync } from "fs";
 
 const base64String = readFileSync("build/math.wasm", "base64");
 
-writeFileSync("build/math.js", `export const MathWasmBase64 = "${base64String}";`);
+writeFileSync("build/math.js", `export const MathWasmBase64 = "data:application/wasm;base64,${base64String}";`);

--- a/test/index.js
+++ b/test/index.js
@@ -2,4 +2,4 @@ import { f64_pow } from "../index.js";
 import assert from "assert";
 
 assert(f64_pow(2, 2) === 4, "2^2 == 4");
-assert(f64_pow(10, -5) === 0.00001, "2^2 == 4");
+assert(f64_pow(10, -5) === 0.00001, "10^-5 == 0.00001");


### PR DESCRIPTION
Browsers don't have `Buffer`, but we can use `fetch` with data URIs with `WebAssembly.instantiateStreaming`.

One caveat: AssemblyScript supports Node v18+, but `WebAssembly.instantiateStreaming` was added in v18.1.0. This means AssemblyScript would have to bump its `engines.node` to be `>=18.1.0`, which is a breaking change but not a particularly impactful one. We can also just bump it to `>=20` since Node v18 has reached end-of-life.